### PR TITLE
Remove unneeded docker install from new approach

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -73,7 +73,6 @@ function tldr_just_work_old()
 function tldr_just_work()
 {
 	prereqs && \
-	install_docker && \
 	install_crypt_setup_mod_scripts && \
 	update_initramfs && \
 	echo SystemD with TPM2 installation complete.


### PR DESCRIPTION
Docker is only needed for building the custom version of systemd, correct?