### PR TITLE
Allow fallback to interactive key entry if TPM2 fails

### DIFF
--- a/patches/cryptroot.patch
+++ b/patches/cryptroot.patch
@@ -2,12 +2,18 @@ diff --git a/cryptroot.orig b/cryptroot
 index 8604084..e704949 100755
 --- a/cryptroot.orig
 +++ b/cryptroot
-@@ -155,7 +155,7 @@ setup_mapping() {
+@@ -155,10 +155,10 @@ setup_mapping() {
  
      local count=0 maxtries="${CRYPTTAB_OPTION_tries:-3}" fstype vg rv
      while [ $maxtries -le 0 ] || [ $count -lt $maxtries ]; do
 -        if [ -z "${CRYPTTAB_OPTION_keyscript+x}" ] && [ "$CRYPTTAB_KEY" != "none" ]; then
-+        if [ -z "${CRYPTTAB_OPTION_keyscript+x}" ] && ( [ -n "${CRYPTTAB_OPTION_tpm2_device}" ] || [ "$CRYPTTAB_KEY" != "none" ] ); then
-             # unlock via keyfile
-             unlock_mapping "$CRYPTTAB_KEY"
-         else
+-            # unlock via keyfile
+-            unlock_mapping "$CRYPTTAB_KEY"
+-        else
++        # If keyscript is provided, unlock with it.
++        # If keyfile or TPM2 device are provided, unlock with them.
++        # If keyfile/TPM2 is not provided (or if they fail to unlock), fall back to interactive unlock.
++        if ! ([ -z "${CRYPTTAB_OPTION_keyscript+x}" ] && ([ -n "${CRYPTTAB_OPTION_tpm2_device}" ] || [ "$CRYPTTAB_KEY" != "none" ]) && unlock_mapping "$CRYPTTAB_KEY"); then
+             # unlock interactively or via keyscript
+             run_keyscript "$count" | unlock_mapping
+         fi

--- a/patches/cryptsetup_functions.patch
+++ b/patches/cryptsetup_functions.patch
@@ -34,7 +34,7 @@ index 339f0fd..a949c6a 100644
          unset -v CRYPTTAB_OPTION_keyslot
      fi
  
-+    if [[ -z "${CRYPTTAB_OPTION_tpm2_device}" ]] ; then
++    if [[ -z "${CRYPTTAB_OPTION_tpm2_device}" ]] || [ "$keyfile" = "-" ]; then
 +
      /sbin/cryptsetup -T1 \
          ${CRYPTTAB_OPTION_header:+--header="$CRYPTTAB_OPTION_header"} \
@@ -44,7 +44,7 @@ index 339f0fd..a949c6a 100644
          --type="$CRYPTTAB_TYPE" --key-file="$keyfile" \
          open -- "$CRYPTTAB_SOURCE" "$CRYPTTAB_NAME"
 +    else
-+	/lib/systemd/systemd-cryptsetup attach "${CRYPTTAB_NAME}" "${CRYPTTAB_SOURCE}" "${keyfile}" "tpm2-device=${CRYPTTAB_OPTION_tpm2_device}"
++	/lib/systemd/systemd-cryptsetup attach "${CRYPTTAB_NAME}" "${CRYPTTAB_SOURCE}" "${keyfile}" "tpm2-device=${CRYPTTAB_OPTION_tpm2_device},headless"
 +    fi
 +
  }


### PR DESCRIPTION
This PR contains 2 commits that, together, will allow the stock interactive password/key entry to take over if the TPM2 (or keyfile) fails to unlock the disk. If, for instance, you have configured the TPM2 to require that the Linux kernel hasn't been modified but you update it, TPM will not automatically unlock the disk anymore. Currently, it is _technically_ possible to unlock using a regular LUKS key, but only if you're using regular text mode and if you type your password (in plain text without any masking) without being prompted for it. Now, with these commits, it will fall back to whatever default password entry screen is provided by the OS and, if the base OS supports it, allow you to enter your password into a graphical interface or, at the very least, properly prompt you for it and mask what you type in.