### PR TITLE
Add cryptsetup libs to initramfs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+patched/

--- a/install.sh
+++ b/install.sh
@@ -3,7 +3,7 @@
 
 function install_tss2()
 {
-	apt install libtss2-dev libtss2-fapi1 libtss2-rc0 libtss2-tctildr0
+	apt -y install --no-install-recommends libtss2-dev libtss2-fapi1 libtss2-rc0 libtss2-tctildr0
 }
 
 function mkcrypttab()

--- a/mkcrypttab.sh
+++ b/mkcrypttab.sh
@@ -5,8 +5,8 @@ volname="${2:-luks}"
 
 if [[ -z "${dev}" ]]; then
     #default to use current root.
-    dev="$(mount  | grep 'on / ' | awk '{print $1;}')"
+    dev=$(awk '{if ( $2 == "/") { print $1}}' /proc/mounts)
     echo "Cryptab: Defaulting to current root device: ${dev}" 1>&2
 fi
 
-echo "${volname} $(sudo blkid --output export "${dev}"  | grep ^UUID) none tpm2-device=auto"
+echo "${volname} $(lsblk -n -o uuid "${dev}") none tpm2-device=auto"

--- a/scripts/systemd_cryptsetup_hook
+++ b/scripts/systemd_cryptsetup_hook
@@ -24,3 +24,8 @@ for i in /lib/x86_64-linux-gnu/libtss2*
 do
 	copy_exec ${i} /lib/x86_64-linux-gnu
 done
+
+for i in /lib/x86_64-linux-gnu/cryptsetup/*
+do
+	copy_file ${i} ${i}
+done


### PR DESCRIPTION
I've used this script on Debian 12 but initramfs lacks cryptsetup libs.

This PR aims to correct that.

Maybe a duplicate of https://github.com/wmcelderry/systemd_with_tpm2/pull/10/files